### PR TITLE
Fix crash in mcfly latest when MCFLY_HISTFILE is not set.

### DIFF
--- a/src/mcfly/devcontainer-feature.json
+++ b/src/mcfly/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "mcfly",
     "id": "mcfly",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs mcfly, which replaces your shell history with an intelligent search engine.",
     "options": {
         "architecture": {

--- a/src/mcfly/install.sh
+++ b/src/mcfly/install.sh
@@ -50,10 +50,12 @@ if [ "${AUTO_ENABLE}" = "true" ]; then
 
     echo "Adding mcfly to ${BASHRC} and ${ZSHRC}"
     if [ -z "$(grep \"mcfly init bash\" ${BASHRC})" ]; then
-        echo -e "eval \"\$(mcfly init bash)\"" >>${BASHRC}
+        echo -e "export MCFLY_HISTFILE=\"\${HISTFILE:-\$HOME/.bash_history}\"" >>${BASHRC}
+        echo -e "source <(mcfly init bash)" >>${BASHRC}
     fi
 
     if [ -z "$(grep \"mcfly init zsh\" ${ZSHRC})"]; then
-        echo -e "eval \"\$(mcfly init zsh)\"" >>${ZSHRC}
+        echo -e "export MCFLY_HISTFILE=\"\${HISTFILE:-\$HOME/.zsh_history}\"" >>${ZSHRC}
+        echo -e "source <(mcfly init zsh)" >>${ZSHRC}
     fi
 fi

--- a/test/mcfly/test.sh
+++ b/test/mcfly/test.sh
@@ -23,9 +23,9 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "version" bash -c "mcfly -V | grep 'McFly'"
-check "bash-integration" bash -c "cat ~/.bashrc | grep 'eval \"\$(mcfly init bash)\"'"
-check "zsh-integration" bash -c "cat ~/.zshrc | grep 'eval \"\$(mcfly init zsh)\"'"
+check "version" bash -c "mcfly -V | grep -i mcfly"
+check "bash-integration" bash -c "cat ~/.bashrc | grep 'source <(mcfly init bash)'"
+check "zsh-integration" bash -c "cat ~/.zshrc | grep 'source <(mcfly init zsh)'"
 
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
Until cantino/mcfly#315 lands, mcfly will crash trying to load the history file, because it cannot explicitly see that it is set in the shell using the shell's HISTFILE environment variable.

I also switched how the shell initialization happens. Instead of calling eval, we just source the output of mcfly init <shell>.