### PR TITLE
Add feature: easy-container-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ environment variables based on the current working directory.
     "ghcr.io/ChristopherMacGown/devcontainer-features/direnv:1": {}
 }
 ```
-
 Additional options can be found in the [feature documentation](src/direnv/README.md).
+
+
+### easy-container-hooks
+This is a cross-distribution devcontainer feature that installs static script runners to /usr/local/bin that will execute scripts located in your devcontainer's local hooks directory.
+
+#### usage
+```json
+"features": {
+    "ghcr.io/ChristopherMacGown/devcontainer-feautres/easy-container-hooks:1":{}
+}
+```
+Additional options can be found in the [feature documentation](src/easy-container-hooks/README.md).
 
 
 ### minio-client

--- a/src/easy-container-hooks/devcontainer-feature.json
+++ b/src/easy-container-hooks/devcontainer-feature.json
@@ -1,0 +1,41 @@
+{
+    "name": "easy-container-hooks",
+    "description": "Shell runner that executes hooks in your .devcontainer/hooks/ directory.",
+    "options": {
+        "hooksDir": {
+            "description": "",
+            "type": "string",
+            "default": ".devcontainer/hooks"
+        },
+        "onCreateHookPath": {
+            "description": "",
+            "type": "string",
+            "default": "on-create"
+        },
+        "postAttachHookPath": {
+            "description": "",
+            "type": "string",
+            "default": "post-attach"
+        },
+        "postCreateHookPath": {
+            "description": "",
+            "type": "string",
+            "default": "post-create"
+        },
+        "postStartHookPath": {
+            "description": "",
+            "type": "string",
+            "default": "post-start"
+        },
+        "updateContentHookPath": {
+            "description": "",
+            "type": "string",
+            "default": "update-content"
+        }
+    },
+    "onCreateCommand" :     ["/usr/local/bin/ezdc_onCreate.sh"],
+    "postCreateCommand":    ["/usr/local/bin/ezdc_postCreate.sh"],
+    "postStartCommand":     ["/usr/local/bin/ezdc_postStart.sh"],
+    "postAttachCommand":    ["/usr/local/bin/ezdc_postAttach.sh"],
+    "updateContentCommand": ["/usr/local/bin/ezdc_updateContent.sh"]
+}

--- a/src/easy-container-hooks/install.sh
+++ b/src/easy-container-hooks/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+set -exou pipefail
+
+DEVCONTAINER_HOOK_DIR=${HOOKSDIR%%+(/)}
+
+function get_hook_dir() {
+    case $1 in
+        onCreate)
+            echo ${ONCREATEHOOKPATH}
+            ;;
+        postAttach)
+            echo ${POSTATTACHHOOKPATH}
+            ;;
+        postCreate)
+            echo ${POSTCREATEHOOKPATH}
+            ;;
+        postStart)
+            echo ${POSTSTARTHOOKPATH}
+            ;;
+        updateContent)
+            echo ${UPDATECONTENTHOOKPATH}
+            ;;
+        *)
+            echo "UNKNOWN HOOK: $1";
+            exit 1
+    esac
+}
+
+function emit_hook() {
+    local HOOK_DIR=$(realpath --relative-to=. -m $1);
+
+    cat ./run-hook.sh.tmpl | sed "s@#####REPLACE######@${HOOK_DIR}@";
+}
+
+for hook in "onCreate" "postAttach" "postCreate" "postStart" "updateContent"; do
+    HOOK_DIR="${DEVCONTAINER_HOOK_DIR}/$(get_hook_dir ${hook} )";
+
+    emit_hook $HOOK_DIR > /usr/local/bin/ezdc_${hook}.sh;
+    chmod +x /usr/local/bin/ezdc_${hook}.sh;
+done

--- a/src/easy-container-hooks/run-hook.sh.tmpl
+++ b/src/easy-container-hooks/run-hook.sh.tmpl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+HOOKS=#####REPLACE######
+WORKSPACE_DIR=$(pwd);
+WORKSPACE_HOOKS=${WORKSPACE_DIR}/${HOOKS};
+for HOOK in $(ls ${WORKSPACE_HOOKS}); do 
+    env WORKSPACE_DIR=${WORKSPACE_DIR} bash "${WORKSPACE_HOOKS}/${HOOK}"
+done
+

--- a/test/easy-container-hooks/changed_hooks_dir.sh
+++ b/test/easy-container-hooks/changed_hooks_dir.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the "easy-container-hooks" feature with no options.
+#
+#
+# This test can be run with the following command:
+#
+#    devcontainer features test \ 
+#                   --features easy-container-hooks \
+#                   --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#                   .
+
+set -e
+
+source dev-container-features-test-lib
+source ./lib.sh
+
+for HOOK in "on-create" "post-attach" "post-create" "post-start" "update-content"; do
+    HOOK_DIR=".devcontainer/skooh/${HOOK}";
+
+    ensure_hook_dir ${HOOK_DIR}
+    write_test_hook ${HOOK_DIR}
+    test_hook ${HOOK_DIR} ${HOOK}
+done
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/easy-container-hooks/changed_oncreatehook_dir.sh
+++ b/test/easy-container-hooks/changed_oncreatehook_dir.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the "easy-container-hooks" feature with no options.
+#
+#
+# This test can be run with the following command:
+#
+#    devcontainer features test \ 
+#                   --features easy-container-hooks \
+#                   --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#                   .
+
+set -e
+
+source dev-container-features-test-lib
+source ./lib.sh
+
+for HOOK in "on-create" "post-attach" "post-create" "post-start" "update-content"; do
+    HOOK_DIR=".devcontainer/hooks/$HOOK";
+    if [[ ${HOOK} = "on-create" ]]; then
+        HOOK_DIR=".devcontainer/hooks/create-on";
+    fi
+    ensure_hook_dir ${HOOK_DIR}
+    write_test_hook ${HOOK_DIR} ${HOOK}
+    test_hook ${HOOK_DIR} ${HOOK}
+done
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/easy-container-hooks/changed_postcreatehook_dir.sh
+++ b/test/easy-container-hooks/changed_postcreatehook_dir.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the "easy-container-hooks" feature with no options.
+#
+#
+# This test can be run with the following command:
+#
+#    devcontainer features test \ 
+#                   --features easy-container-hooks \
+#                   --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#                   .
+
+set -e
+
+source dev-container-features-test-lib
+source ./lib.sh
+
+for HOOK in "on-create" "post-attach" "post-create" "post-start" "update-content"; do
+    HOOK_DIR=".devcontainer/hooks/$HOOK";
+    if [[ ${HOOK} = "post-create" ]]; then
+        HOOK_DIR=".devcontainer/hooks/create-post";
+    fi
+    ensure_hook_dir ${HOOK_DIR}
+    write_test_hook ${HOOK_DIR} ${HOOK}
+    test_hook ${HOOK_DIR} ${HOOK}
+done
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/easy-container-hooks/lib.sh
+++ b/test/easy-container-hooks/lib.sh
@@ -1,0 +1,34 @@
+function ensure_hook_dir() {
+    mkdir -p $1;
+}
+
+function write_test_hook() {
+    OUTPUT=${2:-$(basename $1)};
+    cat <<HOOK > "$1/test_${OUTPUT}.sh"
+#!/usr/bin/env bash
+
+set -e
+
+echo ${OUTPUT}
+HOOK
+}
+
+function get_hook_runner() {
+    case $1 in
+        on-create)      echo "/usr/local/bin/ezdc_onCreate.sh";;
+        post-attach)    echo "/usr/local/bin/ezdc_postAttach.sh";;
+        post-create)    echo "/usr/local/bin/ezdc_postCreate.sh";;
+        post-start)     echo "/usr/local/bin/ezdc_postStart.sh";;
+        update-content) echo "/usr/local/bin/ezdc_updateContent.sh";;
+    esac
+}
+
+function test_hook() {
+    EXPECTATION=$1
+    HOOK=$2
+
+    cat $(get_hook_runner $HOOK)
+
+    check "runner-installed $HOOK" bash -c "cat $(get_hook_runner $HOOK) | grep HOOKS=${EXPECTATION}"
+    check "runner-runs-hooks $HOOK" bash -c "$(get_hook_runner $HOOK) | grep $HOOK"
+}

--- a/test/easy-container-hooks/scenarios.json
+++ b/test/easy-container-hooks/scenarios.json
@@ -1,0 +1,26 @@
+{
+    "changed_hooks_dir": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "features": {
+            "easy-container-hooks": {
+                "hooksDir": ".devcontainer/skooh/"
+            }
+        }
+    },
+    "changed_oncreatehook_dir": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "features": {
+            "easy-container-hooks": {
+                "onCreateHookPath": "create-on"
+            }
+        }
+    },
+    "changed_postcreatehook_dir": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "features": {
+            "easy-container-hooks": {
+                "postCreateHookPath": "create-post"
+            }
+        }
+    }
+}

--- a/test/easy-container-hooks/test.sh
+++ b/test/easy-container-hooks/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the "easy-container-hooks" feature with no options.
+#
+#
+# This test can be run with the following command:
+#
+#    devcontainer features test \ 
+#                   --features easy-container-hooks \
+#                   --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+#                   .
+
+set -e
+
+source dev-container-features-test-lib
+source ./lib.sh
+
+for HOOK in "on-create" "post-attach" "post-create" "post-start" "update-content"; do
+    HOOK_DIR=".devcontainer/hooks/${HOOK}";
+
+    ensure_hook_dir ${HOOK_DIR}
+    write_test_hook ${HOOK_DIR}
+    test_hook ${HOOK_DIR} ${HOOK}
+done
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
This is a cross-distribution devcontainer feature that installs static script runners for scripts located within a configurable hooks directory within your devcontainer configuration.