### PR TITLE
enables setting version for minio client

### DIFF
--- a/src/minio-client/devcontainer-feature.json
+++ b/src/minio-client/devcontainer-feature.json
@@ -28,6 +28,11 @@
                 "arm",
                 "arm64"
             ]
+        },
+        "version": {
+            "type": "string",
+            "default": "",
+            "description": "The version to the minio client, e.g. RELEASE.2025-08-13T08-35-41Z. Find at https://github.com/minio/mc/releases"
         }
     }
 }

--- a/src/minio-client/install.sh
+++ b/src/minio-client/install.sh
@@ -37,6 +37,18 @@ fi
 export MINIO_ARCH
 echo "Arch is ${MINIO_ARCH}"
 
+if [ -z "${VERSION+x}" ]
+then
+    MINIO_DL_BINARY="mc"
+    echo "Version is latest"
+else
+    echo $VERSION
+    MINIO_DL_BINARY="mc.RELEASE.${VERSION}"
+    echo "Version is ${VERSION}"
+fi
+
+echo "Binay name of mc client to download is ${MINIO_DL_BINARY}"
+
 DOWNLOAD_PATH="https://dl.min.io/client/mc/release/${MINIO_VENDOR}-${MINIO_ARCH}/"
 
 # Ensure apt is in non-interactive to avoid prompts
@@ -45,7 +57,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo "Activating feature 'minio-client'"
 check_packages apt-transport-https curl ca-certificates
 
-RELEASE_HASH=$(curl -sL "${DOWNLOAD_PATH}/mc.sha256sum")
+RELEASE_HASH=$(curl -sL "${DOWNLOAD_PATH}/${MINIO_DL_BINARY}.sha256sum")
 RELEASE_FILE=${RELEASE_HASH#* }
 
 curl -sLO "${DOWNLOAD_PATH}/${RELEASE_FILE}"


### PR DESCRIPTION
Enables defining minio client version rather that just pulling latest by default.
Untested. Should work.